### PR TITLE
only set server password if needed

### DIFF
--- a/server.go
+++ b/server.go
@@ -122,7 +122,7 @@ func (s *Server) StartVerifier(ticker *time.Ticker) {
 			}
 		case <-s.StopVerifier:
 			Logger.Debug("Stopping logger for lobby %d", s.LobbyId)
-			s.Rcon.Query("[tf2stadium.com] Lobby Ended.")
+			s.Rcon.Say("[tf2stadium.com] Lobby Ended.")
 			ticker.Stop()
 			RconListener.Close(s.Rcon)
 			s.Rcon.Close()

--- a/server.go
+++ b/server.go
@@ -294,8 +294,14 @@ func (s *Server) ExecConfig() error {
 // runs each 10 sec
 func (s *Server) Verify() bool {
 	//Logger.Debug("#%d: Verifying %s...", s.LobbyId, s.Info.Host)
-	var err = s.Rcon.ChangeServerPassword(s.Info.ServerPassword)
+	password, err := s.Rcon.Query("sv_password")
+	if err != nil {
+		if password == s.Info.ServerPassword {
+			return true
+		}
+	}
 
+	err = s.Rcon.ChangeServerPassword(s.Info.ServerPassword)
 	retries := 0
 	for err != nil { //TODO: Stop connection after x retries
 		if retries == 6 {

--- a/server.go
+++ b/server.go
@@ -294,7 +294,7 @@ func (s *Server) ExecConfig() error {
 // runs each 10 sec
 func (s *Server) Verify() bool {
 	//Logger.Debug("#%d: Verifying %s...", s.LobbyId, s.Info.Host)
-	password, err := s.Rcon.Query("sv_password")
+	password, err := s.Rcon.GetServerPassword()
 	if err != nil {
 		if password == s.Info.ServerPassword {
 			return true


### PR DESCRIPTION
Otherwise players in game see this message spammed over and over: `Server cvar 'sv_password' changed to ***PROTECTED***`

and a small Query -> Say fix :)
